### PR TITLE
Shopper app/homeremodel Ref #121

### DIFF
--- a/shopper-app/src/components/Carousel.tsx
+++ b/shopper-app/src/components/Carousel.tsx
@@ -6,6 +6,8 @@ import CustomCard from './Card';
 import { Typography } from '@mui/material';
 import { BoxProps } from '@mui/material/Box';
 import { useRouter } from 'next/router';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 
 // https://www.npmjs.com/package/react-material-ui-carousel
 
@@ -23,20 +25,38 @@ interface ImageCarouselProps extends BoxProps {
 
 interface ItemProps extends BoxProps {
   item: Image;
-  height: number;
 }
 
 export default function ImageCarousel({ images, height, ...rest }: ImageCarouselProps) {
   return (
-    <Carousel animation="slide" height={height} indicators={false} navButtonsAlwaysVisible={true}>
+    <Carousel
+      NextIcon={<ArrowForwardIosIcon fontSize='large'/>}
+      PrevIcon={<ArrowBackIosIcon fontSize='large'/>}
+      navButtonsProps={{          // Change the colors and radius of the actual buttons. THIS STYLES BOTH BUTTONS
+        style: {
+            backgroundColor: 'transparent',
+            borderRadius: 0
+        }
+      }}
+      navButtonsWrapperProps={{   // Move the buttons to the bottom. Unsetting top here to override default style.
+        style: {
+            bottom: 'unset',
+            top: '15%'
+        }
+      }} 
+      fullHeightHover={false}
+      animation="slide"
+      indicators={false}
+      height={height}
+      navButtonsAlwaysVisible={true}>
       {images.map((item, i) => (
-        <Item key={i} item={item} height={height} {...rest} />
+        <Item key={i} item={item} {...rest} />
       ))}
     </Carousel>
   );
 }
 
-function Item({ item, height, ...rest }: ItemProps) {
+function Item({ item, ...rest }: ItemProps) {
   const router = useRouter();
   const handleProductRedirect = (id: string) => {
     router.push(`/product/${id}`);
@@ -44,23 +64,18 @@ function Item({ item, height, ...rest }: ItemProps) {
 
   return (
     <Box
-      display="flex"
-      justifyContent="center"
-      alignItems="center"
-      maxHeight={height}
-      height={height}
+      position='relative'
+      height="100%"
+      width="100%"
       sx={{ backgroundColor: 'E4E6E6', cursor: 'pointer' }}
-      overflow="hidden"
       onClick={() => handleProductRedirect(item.id)}
       {...rest}
     >
       <img
         style={{
-          maxWidth: '100%',
-          maxHeight: '100%',
           width: '100%',
           height: '100%',
-          objectFit: 'contain'
+          objectFit: 'cover'
         }}
         alt={item.description}
         src={item.image}

--- a/shopper-app/src/components/Carousel.tsx
+++ b/shopper-app/src/components/Carousel.tsx
@@ -21,13 +21,15 @@ export type Image = {
 interface ImageCarouselProps extends BoxProps {
   images: Image[];
   height: number;
+  mobile: boolean;
 }
 
 interface ItemProps extends BoxProps {
   item: Image;
+  mobile: boolean;
 }
 
-export default function ImageCarousel({ images, height, ...rest }: ImageCarouselProps) {
+export default function ImageCarousel({ images, height, mobile, ...rest }: ImageCarouselProps) {
   return (
     <Carousel
       NextIcon={<ArrowForwardIosIcon fontSize='large'/>}
@@ -38,25 +40,25 @@ export default function ImageCarousel({ images, height, ...rest }: ImageCarousel
             borderRadius: 0
         }
       }}
-      navButtonsWrapperProps={{   // Move the buttons to the bottom. Unsetting top here to override default style.
+      navButtonsWrapperProps={mobile ? {} : {   // Move the buttons to the bottom. Unsetting top here to override default style.
         style: {
             bottom: 'unset',
             top: '15%'
         }
       }} 
-      fullHeightHover={false}
+      fullHeightHover={mobile ? true : false}
       animation="slide"
       indicators={false}
       height={height}
       navButtonsAlwaysVisible={true}>
       {images.map((item, i) => (
-        <Item key={i} item={item} {...rest} />
+        <Item key={i} item={item} mobile={mobile} {...rest} />
       ))}
     </Carousel>
   );
 }
 
-function Item({ item, ...rest }: ItemProps) {
+function Item({ item, mobile, ...rest }: ItemProps) {
   const router = useRouter();
   const handleProductRedirect = (id: string) => {
     router.push(`/product/${id}`);
@@ -72,11 +74,17 @@ function Item({ item, ...rest }: ItemProps) {
       {...rest}
     >
       <img
-        style={{
+        style={mobile ? {
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain'
+        } : 
+        {
           width: '100%',
           height: '100%',
           objectFit: 'cover'
-        }}
+        } 
+      }
         alt={item.description}
         src={item.image}
       />

--- a/shopper-app/src/components/CategoryCard.tsx
+++ b/shopper-app/src/components/CategoryCard.tsx
@@ -27,6 +27,7 @@ export default function CategoryCard({ images, title }: CategoryCardProps) {
 
   return (
     <CustomCard
+      type='pointy'
       elevation={0}
       sx={{
         width: isSmallScreen ? '100%' : 'auto',
@@ -34,7 +35,7 @@ export default function CategoryCard({ images, title }: CategoryCardProps) {
         margin: 1,
         alignItems: 'center',
         maxHeight: '100%',
-        maxWidth: isSmallScreen ? '100%' : '300px',
+        maxWidth: isSmallScreen ? '100%' : '400px',
         justifyContent: 'center',
         display: 'flex',
         flexGrow: 1,
@@ -47,12 +48,12 @@ export default function CategoryCard({ images, title }: CategoryCardProps) {
           rowGap: 0.5,
           gridTemplateColumns: 'repeat(2, 1fr)',
           flexGrow: 1,
-          m: 2,
+          m: '20px',
         }}
         alignItems="start"
         justifyContent="center"
       >
-        <Typography sx={{ gridColumn: 'span 2', mb: 0.1 }} align="left" variant="subtitle1">
+        <Typography sx={{ gridColumn: 'span 2', mb: 0.1, fontWeight: 'bold', fontSize: '21px', marginBottom: '10px' }} align="left" >
           {title}
         </Typography>
         {images.slice(0, 4).map((image, key) => (
@@ -60,8 +61,8 @@ export default function CategoryCard({ images, title }: CategoryCardProps) {
             key={key + image.id}
             display="flex"
             flexDirection="column"
-            alignItems= {isSmallScreen ? "center" : "start"}
-            sx={{ height: 'auto', width: 'auto', maxHeight: '100%', maxWidth: '100%' }}
+            alignItems="center"
+            sx={{ height: 'auto', width: 'auto', maxHeight: '100%', maxWidth: '100%', marginBottom: '20px' }}
           >
             <Box
               sx={{

--- a/shopper-app/src/components/MultiCarousel.tsx
+++ b/shopper-app/src/components/MultiCarousel.tsx
@@ -31,7 +31,7 @@ interface ItemProps extends BoxProps {
 
 export default function MultiImageCarousel({ images, height, title, ...rest }: MultiImageCarouselProps) {
   return (
-    <CustomCard sx={{bgcolor: '#FFFFFF', padding: '10px 20px', mb: 1}}>
+    <CustomCard type="pointy" sx={{bgcolor: '#FFFFFF', padding: '10px 20px', mb: 1}}>
       <Typography sx={{mt: '10px', mb: '5px'}} variant='h6'>
         {title}
       </Typography>

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -18,48 +18,70 @@ import { LoginContext } from '@/context/Login';
 
 const advertisements: Image[] = [
   {
-    image: 'https://www.adsoftheworld.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBM0VPQVE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5f561cccbacc4de85a9899b83b437ace43713b41/thumbnail_219710',
+    image: 'https://m.media-amazon.com/images/I/61JRTDaOgTL._SX3000_.jpg',
     id: '2f804cfb-c81a-43e2-9e78-9160332e46bd',
     description: 'Adidas ad',
     title: 'Adidas shoes'
   },
   {
-    image: 'https://fcdn.me/a59/10a/adidas-run-for-the-oceans-5-33863c5db68f48f9e180fc12aa.jpg?d=1',
+    image: 'https://m.media-amazon.com/images/I/717a5OeZ6iL._SX3000_.jpg',
     id: '2f804cfb-c81a-43e2-9e78-9160332e46bd',
     description: 'Adidas Sea ad',
     title: 'Adidas women shoes'
   },
   {
-    image: 'https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/e456a8103211209.5f47dea744a23.jpg',
+    image: 'https://m.media-amazon.com/images/I/517HzrpIwAL._SX3000_.jpg',
     id: 'd0eeec78-99ef-4736-8256-c04043110873',
     description: 'Nike ad',
     title: 'Nike shoes'
   },
   {
-    image: 'https://i.ytimg.com/vi/8ly_IRib75Q/maxresdefault.jpg',
+    image: 'https://m.media-amazon.com/images/I/71UY8rxRxUL._SX3000_.jpg',
     id: 'd9b42b3d-aa46-4791-8470-c9417d1db025',
     description: 'Samsung Galaxy ad',
     title: 'Samsung'
   },
   {
-    image: 'https://i.ytimg.com/vi/YIjLnWmLhmk/maxresdefault.jpg',
+    image: 'https://m.media-amazon.com/images/I/71cpVVPylML._SX3000_.jpg',
     id: 'c85ddd6d-c3ef-4ba2-8951-a6f377c4fe94',
     description: 'Spalding basketball ad',
     title: 'Spalding'
   },
   {
-    image: 'https://media.idownloadblog.com/wp-content/uploads/2016/10/macbook-air.png',
+    image: 'https://m.media-amazon.com/images/I/71BewpxvEZL._SX3000_.jpg',
     id: 'fcdfc6a7-3e50-4909-818c-379f75b4320a',
     description: 'Apple ad',
     title: 'Macbooks'
   },
   {
-    image: 'https://image.adsoftheworld.com/d50xigu5cjitc14142pboshuox6f',
+    image: 'https://m.media-amazon.com/images/I/61AHFjQsfDL._SX3000_.jpg',
     id: 'fcab207a-fd48-4e81-a15d-a754f49fcd15',
     description: 'Lamp ad',
     title: 'Lamps'
   },
 ]
+
+const categories: string[] = [
+  'furniture',
+  'electronics',
+  'sports',
+  'apple',
+  'shrek',
+  'home',
+  'shoes',
+  'clothing',
+  'adidas',
+  'nike',
+  'gaming',
+  'couch',
+  'storage', 
+  'kitchen',
+]
+
+const getRandomCategory = () => {
+  const randomElement = categories[Math.floor(Math.random() * categories.length)];
+  return randomElement;
+}
 
 const fetchProducts = async (category: string): Promise<Product[]> => {
   try {
@@ -98,9 +120,7 @@ const fetchProducts = async (category: string): Promise<Product[]> => {
 // card of category component
 export function Home() {
   const [ads, setAds] = React.useState<Image[]>(advertisements);
-  const [category1, setCategory1] = React.useState<Image[]>([]);
-  const [category2, setCategory2] = React.useState<Image[]>([]);
-  const [category3, setCategory3] = React.useState<Image[]>([]);
+  const [categoriesData, setCategoriesData] = React.useState<{ [key: string]: Image[] }>({});
   const { t } = useTranslation('common');
   const loginContext = React.useContext(LoginContext);
   const theme = useTheme();
@@ -110,40 +130,29 @@ export function Home() {
   React.useEffect(() => {
     const fetchData = async () => {
       try {
-        const category1products = await fetchProducts('furniture');
-        const cat1 = category1products.map((product) => ({
-          image: product.image[0],
-          id: product.id,
-          description: product.name,
-          title: 'sale',
-        }));
-        setCategory1(cat1);
-        const category2products = await fetchProducts('electronics');
-        const cat2 = category2products.map((product) => ({
-          image: product.image[0],
-          id: product.id,
-          description: product.name,
-          title: 'sale',
-        }));
-        setCategory2(cat2);
-        const products = await fetchProducts('sports');
-        const cat3 = products.map((product) => ({
-          image: product.image[0],
-          id: product.id,
-          description: product.name,
-          title: 'sale',
-        }));
-        setCategory3(cat3);
+        const fetchedData: { [key: string]: Image[] } = {};
+        for (let i = 0; i <= 6; i++) {
+          const category = getRandomCategory();
+          const products = await fetchProducts(category);
+          fetchedData[category] = products.map((product) => ({
+            image: product.image[0],
+            id: product.id,
+            description: product.name,
+            title: 'sale',
+          }));
+        }
+        setCategoriesData(fetchedData);
       } catch (error) {
         console.error('Error fetching products:', error);
       }
     };
-
+  
     fetchData();
   }, []);
 
   const easyReturns = (
     <CustomCard
+      type='pointy'
       elevation={0}
       sx={{
         width: 'auto',
@@ -181,18 +190,33 @@ export function Home() {
     </CustomCard>
   );
 
+
+  const loginGrid = (
+    <Grid container spacing={0} justifyContent={isSmallScreen ? 'center' : 'flex-start'}>
+      {Object.entries(categoriesData).slice(0,3).map(([category, images], index) => (
+        <Grid item xs={12} sm={4} md={3} key={category}>
+          <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+            <CategoryCard images={images} title={t(`home.${category}`)} />
+          </Box>
+        </Grid>
+      ))}
+      <Grid item xs={0} sm={0} md={3}>
+        {easyReturns}
+      </Grid>
+    </Grid>
+  );
+
   if (loginContext.role !== 'shopper' && loginContext.accessToken !== '') {
     return <RedirectNonShopper />;
   }
 
   return (
     <React.Fragment>
-      <Box bgcolor="#00FFFF" width="100%" height="400px">
-      </Box>
       <TopBar />
+      
       <Box aria-label="homeproducts" bgcolor="#E4E6E6" maxHeight="100%" sx={{ mb: 0 }}>
         <Box
-          sx={{ maxWidth: { md: '80%', sm: '100%' } }}
+          sx={{ maxWidth: { md: '100%', sm: '100%' }, position: 'relative' }}
           alignItems="center"
           justifyContent="center"
           margin="auto"
@@ -203,32 +227,37 @@ export function Home() {
             alignItems="center"
             bgcolor="#FFFFFF"
           >
-            <ImageCarousel images={ads} height={isSmallScreen ? 300 : 400} />
+            <ImageCarousel images={ads} height={isSmallScreen ? 300 : 600} />
           </Box>
-          <Grid container spacing={0} justifyContent={isSmallScreen ? 'center' : 'flex-start'}>
-            <Grid item xs={12} sm={4} md={3}>
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <CategoryCard images={category1} title={t('home.pick-up')} />
-              </Box>
-            </Grid>
-            <Grid item xs={12} sm={4} md={3}>
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <CategoryCard images={category2} title={t('home.keep-shopping')} />
-              </Box>
-            </Grid>
-            <Grid item xs={12} sm={4} md={3}>
-              <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                <CategoryCard images={category3} title={t('home.top-deal')} />
-              </Box>
-            </Grid>
-            <Grid item xs={0} sm={0} md={3}>
-              {easyReturns}
-            </Grid>
-          </Grid>
-          <MultiImageCarousel images={category2} height={200} title={t('home.top-sellers-electronics')}/>
-          <MultiImageCarousel images={category1} height={200} title={t('home.top-sellers-furniture')}/>
-          <MultiImageCarousel images={category3} height={200} title={t('home.top-sellers-sports')}/>
-
+          <Box
+            sx={{
+              position: 'absolute',
+              top: '250px',
+              width: '100%',
+              zIndex: '100000'
+            }}
+          >
+            {loginGrid}
+          </Box>
+          <Box
+            sx={{
+              background: 'linear-gradient(to bottom, transparent, #E4E6E6)',
+              position: 'absolute',
+              top: '400px',
+              zIndex:'500'
+            }}
+            width="100%"
+            height={200}
+            />
+          <Box bgcolor='#E4E6E6' width="100%" height={50}/>
+          {Object.entries(categoriesData).slice(3,6).map(([category, images]) => (
+            <MultiImageCarousel
+              key={category}
+              images={images}
+              height={200}
+              title={t(`home.top-sellers-${category}`)}
+            />
+          ))}
         </Box>
       </Box>
       <Footer />

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -126,12 +126,14 @@ export function Home() {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const isMedScreen = useMediaQuery(theme.breakpoints.down('md'));
+  // used to determine how many categories there are
+  const numberOfCategories = 8;
 
   React.useEffect(() => {
     const fetchData = async () => {
       try {
         const fetchedData: { [key: string]: Image[] } = {};
-        for (let i = 0; i <= 6; i++) {
+        for (let i = 0; i <= numberOfCategories; i++) {
           const category = getRandomCategory();
           const products = await fetchProducts(category);
           fetchedData[category] = products.map((product) => ({
@@ -191,8 +193,8 @@ export function Home() {
   );
 
 
-  const loginGrid = (
-    <Grid container spacing={0} justifyContent={isSmallScreen ? 'center' : 'flex-start'}>
+  const logoutGrid = (
+    <Grid container spacing={0} justifyContent='center'>
       {Object.entries(categoriesData).slice(0,3).map(([category, images], index) => (
         <Grid item xs={12} sm={4} md={3} key={category}>
           <Box sx={{ display: 'flex', justifyContent: 'center' }}>
@@ -227,30 +229,38 @@ export function Home() {
             alignItems="center"
             bgcolor="#FFFFFF"
           >
-            <ImageCarousel images={ads} height={isSmallScreen ? 300 : 600} />
+            <ImageCarousel images={ads} height={isSmallScreen ? 300 : 600} mobile={isSmallScreen}/>
           </Box>
-          <Box
-            sx={{
-              position: 'absolute',
-              top: '250px',
-              width: '100%',
-              zIndex: '100000'
-            }}
-          >
-            {loginGrid}
-          </Box>
-          <Box
-            sx={{
-              background: 'linear-gradient(to bottom, transparent, #E4E6E6)',
-              position: 'absolute',
-              top: '400px',
-              zIndex:'500'
-            }}
-            width="100%"
-            height={200}
-            />
-          <Box bgcolor='#E4E6E6' width="100%" height={50}/>
-          {Object.entries(categoriesData).slice(3,6).map(([category, images]) => (
+          {
+            !isSmallScreen &&
+            <React.Fragment>
+              <Box
+                sx={{
+                  position: 'absolute',
+                  top: '250px',
+                  width: '100%',
+                  zIndex: '100000'
+                }}
+                justifyItems='center'
+              >
+                {logoutGrid}
+              </Box>
+              <Box
+                sx={{
+                  background: 'linear-gradient(to bottom, transparent, #E4E6E6)',
+                  position: 'absolute',
+                  top: '400px',
+                  zIndex:'500'
+                }}
+                width="100%"
+                height={200}
+                />
+              <Box bgcolor='#E4E6E6' width="100%" height={50}/>
+            </React.Fragment>
+          }
+
+
+          {Object.entries(categoriesData).slice(3,numberOfCategories).map(([category, images]) => (
             <MultiImageCarousel
               key={category}
               images={images}


### PR DESCRIPTION
Redesigned ad carousel to look more like Amazon, made cards more pointy, and randomized products from each category. Removed the "pick up where you left off" stuff for now since browser history is not implemented yet. Categories are randomized, but still hardcoded inside of Home.jsx, so we will need to work on category database first before deciding specific categories / category translations.



<img width="1413" alt="Screenshot 2024-07-06 at 4 40 49 PM" src="https://github.com/sikwong2/amazon/assets/122410161/8cada0ed-6d12-4e3a-9381-3251bf237277">
