### PR TITLE
Shopper app/browser history #62

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ venv/
 
 # submission
 submission.zip
+
+.env

--- a/AccountService/sql/schema.sql
+++ b/AccountService/sql/schema.sql
@@ -2,7 +2,10 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 DROP TABLE IF EXISTS apikeytable;
 DROP TABLE IF EXISTS account;
+DROP TABLE IF EXISTS history;
 
 CREATE TABLE account(id UUID UNIQUE PRIMARY KEY DEFAULT gen_random_uuid(), data jsonb);
 
 CREATE TABLE apikeytable (account_id UUID REFERENCES account(id), api_key text UNIQUE NOT NULL, active boolean DEFAULT true);
+
+CREATE TABLE history(id UUID UNIQUE PRIMARY KEY DEFAULT gen_random_uuid(), account_id UUID REFERENCES account(id), product_id UUID NOT NULL, timestamp TIMESTAMPTZ DEFAULT NOW());

--- a/AccountService/sql/schema.sql
+++ b/AccountService/sql/schema.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 DROP TABLE IF EXISTS apikeytable;
-DROP TABLE IF EXISTS account;
+DROP TABLE IF EXISTS account CASCADE;
 DROP TABLE IF EXISTS history;
 
 CREATE TABLE account(id UUID UNIQUE PRIMARY KEY DEFAULT gen_random_uuid(), data jsonb);

--- a/AccountService/sql/schema.sql
+++ b/AccountService/sql/schema.sql
@@ -8,4 +8,4 @@ CREATE TABLE account(id UUID UNIQUE PRIMARY KEY DEFAULT gen_random_uuid(), data 
 
 CREATE TABLE apikeytable (account_id UUID REFERENCES account(id), api_key text UNIQUE NOT NULL, active boolean DEFAULT true);
 
-CREATE TABLE history(id UUID UNIQUE PRIMARY KEY DEFAULT gen_random_uuid(), account_id UUID REFERENCES account(id), product_id UUID NOT NULL, timestamp TIMESTAMPTZ DEFAULT NOW());
+CREATE TABLE history(account_id UUID REFERENCES account(id), product_id UUID NOT NULL, timestamp TIMESTAMPTZ DEFAULT NOW());

--- a/AccountService/src/member/controller.ts
+++ b/AccountService/src/member/controller.ts
@@ -86,9 +86,15 @@ export class MemberController extends Controller {
   @Get('{memberId}/browser-history')
   @Response('400', 'Bad Request')
   @SuccessResponse('200', 'Good')
-  public async getBrowserHistory(@Path('memberId') memberId: UUID): Promise<BrowserHistoryEntry[] | undefined> {
+  public async getBrowserHistory(
+    @Path('memberId') memberId: UUID,
+    @Query('size') size?: number,
+    @Query('page') page?: number
+  ): Promise<BrowserHistoryEntry[] | undefined> {
+    const p: number = page ? (page - 1) : 0;
+    const s: number = size ? size : 4;
     return new MemberService()
-      .getBrowserHistory(memberId)
+      .getBrowserHistory(memberId, s, p)
       .then(async (response: BrowserHistoryEntry[] | undefined): Promise<BrowserHistoryEntry[] | undefined> => {
         if (response == undefined) {
           this.setStatus(404);
@@ -119,12 +125,11 @@ export class MemberController extends Controller {
   @SuccessResponse('200', 'Deleted')
   public async deleteBrowserHistory(
     @Path('memberId') memberId: UUID,
-    @Query() date: Date
-  ): Promise <boolean> {
+    @Query() date?: Date
+  ): Promise <BrowserHistoryEntry[]> {
+    const t = new Date();
+    const timestamp = date ? date : t;
     return new MemberService()
-      .deleteBrowserHistory(memberId, date)
-      .then(async (response: boolean): Promise <boolean> => {
-        return response;
-      })
+      .deleteBrowserHistory(memberId, timestamp);
   }
 }

--- a/AccountService/src/member/controller.ts
+++ b/AccountService/src/member/controller.ts
@@ -9,13 +9,15 @@ import {
   Response,
   Security,
   Route,
+  Delete,
 } from 'tsoa';
 
-import { MemberInput, Member, Role } from '.';
+import { MemberInput, Member, Role, BrowserHistoryEntry } from '.';
 import { MemberService } from './service';
 import { query } from 'express';
 import { access } from 'fs';
 import { MemberInfo } from '.';
+import { UUID } from '../types/express';
 
 @Route('account')
 export class MemberController extends Controller {
@@ -79,5 +81,50 @@ export class MemberController extends Controller {
         }
         return response;
       });
+  }
+
+  @Get('{memberId}/browser-history')
+  @Response('400', 'Bad Request')
+  @SuccessResponse('200', 'Good')
+  public async getBrowserHistory(@Path('memberId') memberId: UUID): Promise<BrowserHistoryEntry[] | undefined> {
+    return new MemberService()
+      .getBrowserHistory(memberId)
+      .then(async (response: BrowserHistoryEntry[] | undefined): Promise<BrowserHistoryEntry[] | undefined> => {
+        if (response == undefined) {
+          this.setStatus(404);
+        }
+        return response;
+      });
+  }
+
+  @Post('{memberId}/browser-history/{productId}')
+  @Response('400', 'Bad Request')
+  @SuccessResponse('201', 'Created')
+  public async addBrowserHistory(
+    @Path('memberId') memberId: UUID,
+    @Path('productId') productId: UUID
+  ): Promise<BrowserHistoryEntry | undefined> {
+    return new MemberService()
+      .addBrowserHistory(memberId, productId)
+      .then(async (response: BrowserHistoryEntry | undefined): Promise<BrowserHistoryEntry | undefined> => {
+        if (response == undefined) {
+          this.setStatus(400);
+        }
+        return response;
+      })
+  }
+
+  @Delete('{memberId}/browser-history')
+  @Response('400', 'Bad Request')
+  @SuccessResponse('200', 'Deleted')
+  public async deleteBrowserHistory(
+    @Path('memberId') memberId: UUID,
+    @Query() date: Date
+  ): Promise <boolean> {
+    return new MemberService()
+      .deleteBrowserHistory(memberId, date)
+      .then(async (response: boolean): Promise <boolean> => {
+        return response;
+      })
   }
 }

--- a/AccountService/src/member/index.ts
+++ b/AccountService/src/member/index.ts
@@ -16,6 +16,7 @@ export interface Member {
   name: string;
   role: Role;
   status: boolean;
+  
 }
 
 // getting member info for pages like checkout
@@ -26,3 +27,10 @@ export interface MemberInfo {
 
 // can only be shopper or vendor
 export type Role = 'shopper' | 'vendor';
+
+export interface BrowserHistoryEntry {
+  id: UUID,
+  accountId: UUID,
+  productId: UUID,
+  timestamp: Date
+}

--- a/AccountService/src/member/index.ts
+++ b/AccountService/src/member/index.ts
@@ -28,8 +28,8 @@ export interface MemberInfo {
 // can only be shopper or vendor
 export type Role = 'shopper' | 'vendor';
 
+// returned from browser history get 
 export interface BrowserHistoryEntry {
-  id: UUID,
   accountId: UUID,
   productId: UUID,
   timestamp: Date

--- a/AccountService/src/member/service.ts
+++ b/AccountService/src/member/service.ts
@@ -141,11 +141,11 @@ export class MemberService {
 
 
   // gets the 4 most recent products viewed by user
-  public async getBrowserHistory(memberId: UUID): Promise<BrowserHistoryEntry[] | undefined> {
-    let select = `SELECT * FROM history WHERE account_id = $1 ORDER BY timestamp DESC LIMIT 4`;
+  public async getBrowserHistory(memberId: UUID, size: number, page: number): Promise<BrowserHistoryEntry[] | undefined> {
+    let select = `SELECT * FROM history WHERE account_id = $1 ORDER BY timestamp DESC LIMIT $2 OFFSET $3`;
     const query = {
       text: select,
-      values: [memberId]
+      values: [memberId, size, `${page * size}`]
     };
     const {rows} = await pool.query(query);
     return rows;
@@ -163,13 +163,13 @@ export class MemberService {
   }
 
   // deletes browser history based on timestamp
-  public async deleteBrowserHistory(memberId: UUID, date: Date): Promise<boolean> {
-    const select = `DELETE FROM history WHERE account_id = $1 AND timestamp < $2 RETURNING *`;
+  public async deleteBrowserHistory(memberId: UUID, date: Date): Promise<BrowserHistoryEntry[]> {
+    const select = `DELETE FROM history WHERE account_id = $1 AND timestamp <= $2 RETURNING *`;
     const query = {
       text: select,
       values: [memberId, date.toISOString()]
     }
     const {rows} = await pool.query(query);
-    return rows.length > 0;
+    return rows;
   }
 }

--- a/AccountService/src/member/service.ts
+++ b/AccountService/src/member/service.ts
@@ -1,9 +1,10 @@
-import { Member } from '.';
+import { BrowserHistoryEntry, Member } from '.';
 import { MemberInput } from '.';
 import { pool } from '../db';
 import { AccountService } from '../auth/service';
 import { Role } from '.';
 import { MemberInfo } from '.';
+import { UUID } from '../types/express';
 
 export class MemberService {
   // checks if member existing from email before creating account
@@ -136,5 +137,39 @@ export class MemberService {
     returnObj.name = rows[0].accountinfo.name;
     returnObj.address = rows[0].accountinfo.address;
     return returnObj;
+  }
+
+
+  // gets the 4 most recent products viewed by user
+  public async getBrowserHistory(memberId: UUID): Promise<BrowserHistoryEntry[] | undefined> {
+    let select = `SELECT * FROM history WHERE account_id = $1 ORDER BY timestamp DESC LIMIT 4`;
+    const query = {
+      text: select,
+      values: [memberId]
+    };
+    const {rows} = await pool.query(query);
+    return rows;
+  }
+
+  // adds product id to browsing history
+  public async addBrowserHistory(memberId: UUID, productId: UUID): Promise<BrowserHistoryEntry | undefined> {
+    let insert = `INSERT INTO history (account_id, product_id) VALUES ($1, $2) RETURNING *`;
+    const query = {
+      text: insert,
+      values: [memberId, productId]
+    };
+    const {rows} = await pool.query(query);
+    return rows[0];
+  }
+
+  // deletes browser history based on timestamp
+  public async deleteBrowserHistory(memberId: UUID, date: Date): Promise<boolean> {
+    const select = `DELETE FROM history WHERE account_id = $1 AND timestamp < $2 RETURNING *`;
+    const query = {
+      text: select,
+      values: [memberId, date.toISOString()]
+    }
+    const {rows} = await pool.query(query);
+    return rows.length > 0;
   }
 }

--- a/shopper-app/public/locales/en/common.json
+++ b/shopper-app/public/locales/en/common.json
@@ -55,7 +55,8 @@
     "learn-more": "Learn More",
     "top-sellers-sports": "Top Sellers in Sports",
     "top-sellers-electronics": "Top Sellers in Electronics",
-    "top-sellers-furniture": "Top Sellers in Furniture"
+    "top-sellers-furniture": "Top Sellers in Furniture",
+    "browsing-history": "Your Browsing History"
   },
   "cart": {
     "proceed-to-checkout": "Proceed to Checkout",

--- a/shopper-app/public/locales/zh/common.json
+++ b/shopper-app/public/locales/zh/common.json
@@ -55,7 +55,8 @@
     "learn-more": "了解更多",
     "top-sellers-sports": "体育类热销商品",
     "top-sellers-electronics": "电子产品畅销品",
-    "top-sellers-furniture": "家具畅销品"
+    "top-sellers-furniture": "家具畅销品",
+    "browsing-history": "浏览记录"
   },
   "cart": {
     "proceed-to-checkout": "进行结算",

--- a/shopper-app/src/components/CategoryCard.tsx
+++ b/shopper-app/src/components/CategoryCard.tsx
@@ -58,7 +58,7 @@ export default function CategoryCard({ images, title }: CategoryCardProps) {
         </Typography>
         {images.slice(0, 4).map((image, key) => (
           <Box
-            key={key + image.id}
+            key={title + key + image.id}
             display="flex"
             flexDirection="column"
             alignItems="center"

--- a/shopper-app/src/context/BrowserHistory.tsx
+++ b/shopper-app/src/context/BrowserHistory.tsx
@@ -20,14 +20,12 @@ export const BrowserHistoryProvider = ({children}:  PropsWithChildren<{}>) => {
       const storedHistory = sessionStorage.getItem('productHistory');
       setProductHistory(storedHistory ? JSON.parse(storedHistory) : []);
     }
-  }, [isBrowser]);
+  }, []);
 
   const addProductToHistory = (product: string) => {
     const updatedHistory = [...productHistory, product];
     setProductHistory(updatedHistory);
-    if (isBrowser) {
-      sessionStorage.setItem('productHistory', JSON.stringify(updatedHistory));
-    }
+    sessionStorage.setItem('productHistory', JSON.stringify(updatedHistory));
   }
 
   return (

--- a/shopper-app/src/context/BrowserHistory.tsx
+++ b/shopper-app/src/context/BrowserHistory.tsx
@@ -1,19 +1,24 @@
 import { PropsWithChildren, useState, createContext, useEffect } from 'react';
 
 
+interface BrowserHistoryProduct {
+  productId: string;
+  date: Date;
+}
+
 interface BrowserHistoryContextProps {
-  productHistory: string[];
-  addProductToHistory: (product: string) => void;
+  productHistory: BrowserHistoryProduct[];
+  addProductToHistory: (product: BrowserHistoryProduct) => void;
 }
 
 export const BrowserHistoryContext = createContext<BrowserHistoryContextProps>({
   productHistory: [],
-  addProductToHistory: (product: string) => {}
+  addProductToHistory: (product: BrowserHistoryProduct) => {}
 });
 
 export const BrowserHistoryProvider = ({children}:  PropsWithChildren<{}>) => {
   const isBrowser = typeof window !== 'undefined';
-  const [productHistory, setProductHistory] = useState<string[]>([]);
+  const [productHistory, setProductHistory] = useState<BrowserHistoryProduct[]>([]);
 
   useEffect(() => {
     if (isBrowser) {
@@ -22,8 +27,8 @@ export const BrowserHistoryProvider = ({children}:  PropsWithChildren<{}>) => {
     }
   }, []);
 
-  const addProductToHistory = (product: string) => {
-    const updatedHistory = [...productHistory, product];
+  const addProductToHistory = (product: BrowserHistoryProduct) => {
+    const updatedHistory: BrowserHistoryProduct[] = [...productHistory, product];
     setProductHistory(updatedHistory);
     sessionStorage.setItem('productHistory', JSON.stringify(updatedHistory));
   }

--- a/shopper-app/src/context/BrowserHistory.tsx
+++ b/shopper-app/src/context/BrowserHistory.tsx
@@ -1,0 +1,38 @@
+import { PropsWithChildren, useState, createContext, useEffect } from 'react';
+
+
+interface BrowserHistoryContextProps {
+  productHistory: string[];
+  addProductToHistory: (product: string) => void;
+}
+
+export const BrowserHistoryContext = createContext<BrowserHistoryContextProps>({
+  productHistory: [],
+  addProductToHistory: (product: string) => {}
+});
+
+export const BrowserHistoryProvider = ({children}:  PropsWithChildren<{}>) => {
+  const isBrowser = typeof window !== 'undefined';
+  const [productHistory, setProductHistory] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (isBrowser) {
+      const storedHistory = sessionStorage.getItem('productHistory');
+      setProductHistory(storedHistory ? JSON.parse(storedHistory) : []);
+    }
+  }, [isBrowser]);
+
+  const addProductToHistory = (product: string) => {
+    const updatedHistory = [...productHistory, product];
+    setProductHistory(updatedHistory);
+    if (isBrowser) {
+      sessionStorage.setItem('productHistory', JSON.stringify(updatedHistory));
+    }
+  }
+
+  return (
+    <BrowserHistoryContext.Provider value={{productHistory, addProductToHistory}}>
+      {children}
+    </BrowserHistoryContext.Provider>
+  )
+}

--- a/shopper-app/src/graphql/member/resolver.ts
+++ b/shopper-app/src/graphql/member/resolver.ts
@@ -1,6 +1,6 @@
-import { Resolver, Mutation, Arg, Query } from 'type-graphql';
+import { Resolver, Mutation, Arg, Query, Int } from 'type-graphql';
 
-import { Member } from './schema';
+import { BrowserHistoryEntry, Member } from './schema';
 import { MemberRequest } from './schema';
 import { MemberInfo } from './schema';
 import { MemberService } from './service';
@@ -31,5 +31,35 @@ export class MemberResolver {
         }
         return response;
       });
+  }
+
+  @Query((returns) => [BrowserHistoryEntry])
+  async getBrowserHistory(
+    @Arg('memberId') memberId: string,
+    @Arg('page', () => Int, { defaultValue: 1 }) page: number,
+    @Arg('size', () => Int, { defaultValue: 4 }) size: number
+  ): Promise <[BrowserHistoryEntry]> {
+    return new MemberService()
+      .getBrowserHistory(memberId, size, page)
+  }
+
+  @Mutation((returns) => BrowserHistoryEntry)
+  async addBrowserHistory(
+    @Arg('memberId') memberId: string,
+    @Arg('productId') productId: string,
+  ): Promise <BrowserHistoryEntry> {
+    return new MemberService()
+      .addBrowserHistory(memberId, productId)
+  }
+
+  @Mutation((returns) => [BrowserHistoryEntry])
+  async deleteBrowserHistory(
+    @Arg('memberId') memberId: string,
+    @Arg('date', () => Date, { nullable: true }) date?: Date,
+  ): Promise <[BrowserHistoryEntry]> {
+    const today = new Date();
+    const d = date ? date : today;
+    return new MemberService()
+      .deleteBrowserHistory(memberId, d);
   }
 }

--- a/shopper-app/src/graphql/member/schema.ts
+++ b/shopper-app/src/graphql/member/schema.ts
@@ -44,12 +44,6 @@ export class MemberInfo {
 
 @ObjectType('BrowserHistoryEntry')
 export class BrowserHistoryEntry {
-  // @Field(() => ID)
-  // @Matches(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-  // accountId!: string
-  // @Field(() => ID)
-  // @Matches(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
-  // productId!: string
   @Field()
   account_id!: string
   @Field()

--- a/shopper-app/src/graphql/member/schema.ts
+++ b/shopper-app/src/graphql/member/schema.ts
@@ -41,3 +41,19 @@ export class MemberInfo {
   @Field()
   address!: string;
 }
+
+@ObjectType('BrowserHistoryEntry')
+export class BrowserHistoryEntry {
+  // @Field(() => ID)
+  // @Matches(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
+  // accountId!: string
+  // @Field(() => ID)
+  // @Matches(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)
+  // productId!: string
+  @Field()
+  account_id!: string
+  @Field()
+  product_id!: string
+  @Field(() => Date)
+  timestamp!: string
+}

--- a/shopper-app/src/graphql/member/service.ts
+++ b/shopper-app/src/graphql/member/service.ts
@@ -1,6 +1,6 @@
 import { Member } from './schema';
 import { MemberRequest } from './schema';
-import type { MemberInfo } from './schema';
+import type { BrowserHistoryEntry, MemberInfo } from './schema';
 
 export class MemberService {
   async createaccount(memberinput: MemberRequest): Promise<Member | undefined> {
@@ -43,6 +43,64 @@ export class MemberService {
     } catch (e) {
       console.log(e);
       throw new Error('Error in AccountSerivce: getInfo');
+    }
+  }
+
+  async getBrowserHistory(memberId: string, size: number, page: number): Promise<[BrowserHistoryEntry]> {
+    try {
+      const res = await fetch(
+        `http://localhost:${process.env.ACCOUNT_SERVICE_PORT}/api/v0/account/${memberId}/browser-history?size=${size}&page=${page}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      const json = await res.json();
+      return json;
+    } catch(e) {
+      console.log(e);
+      throw new Error('Error in AccountService: getBrowserHistory')
+    }
+  }
+
+  async addBrowserHistory(memberId: string, productId: string): Promise<BrowserHistoryEntry> {
+    try {
+      const res = await fetch(
+        `http://localhost:${process.env.ACCOUNT_SERVICE_PORT}/api/v0/account/${memberId}/browser-history/${productId}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      const json = await res.json();
+      console.log(json);
+      return json;
+    } catch(e) {
+      console.log(e);
+      throw new Error('Error in AccountService: addBrowserHistory');
+    }
+  }
+
+  async deleteBrowserHistory(memberId: string, date: Date): Promise<[BrowserHistoryEntry]> {
+    try {
+      const res = await fetch(
+        `http://localhost:${process.env.ACCOUNT_SERVICE_PORT}/api/v0/account/${memberId}/browser-history?date=${date.toISOString()}`,
+        {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      const json = await res.json();
+      return json;
+    } catch(e) {
+      console.log(e);
+      throw new Error('Error in AccountService: addBrowserHistory');
     }
   }
 }

--- a/shopper-app/src/graphql/member/service.ts
+++ b/shopper-app/src/graphql/member/service.ts
@@ -77,7 +77,6 @@ export class MemberService {
         },
       );
       const json = await res.json();
-      console.log(json);
       return json;
     } catch(e) {
       console.log(e);

--- a/shopper-app/src/pages/_app.tsx
+++ b/shopper-app/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { LoginProvider } from "@/context/Login";
 import { CartProvider } from "@/context/Cart";
 import { PageProvider } from "@/context/Page";
 import { SearchProvider } from '@/context/SearchContext';
+import { BrowserHistoryProvider } from "@/context/BrowserHistory";
 
 const theme = createTheme({
   typography: {
@@ -22,7 +23,9 @@ const App = ({ Component, pageProps }: AppProps) => {
         <SearchProvider>
           <PageProvider>
             <CartProvider>
-              <Component {...pageProps} />
+              <BrowserHistoryProvider>
+                <Component {...pageProps} />
+              </BrowserHistoryProvider>
             </CartProvider>
           </PageProvider>
         </SearchProvider>

--- a/shopper-app/src/pages/product/[productId].tsx
+++ b/shopper-app/src/pages/product/[productId].tsx
@@ -150,11 +150,8 @@ export default function Product({ product }: ProductProp) {
     const fetchBrowserHistory = async () => {
       try {
         if (accessToken === '') {
-          console.log('not logged in adding to browser context');
           addProductToHistory(productId as string);
-          console.log('Product history:', productHistory);
         } else if (accessToken !== '') {
-          console.log('logged in adding to database');
           await addBrowserHistory(id, productId as string);
         }
       } catch(e) {

--- a/shopper-app/src/pages/product/[productId].tsx
+++ b/shopper-app/src/pages/product/[productId].tsx
@@ -150,7 +150,8 @@ export default function Product({ product }: ProductProp) {
     const fetchBrowserHistory = async () => {
       try {
         if (accessToken === '') {
-          addProductToHistory(productId as string);
+          const t = new Date();
+          addProductToHistory({productId: productId as string, date: t});
         } else if (accessToken !== '') {
           await addBrowserHistory(id, productId as string);
         }

--- a/shopper-app/src/pages/product/[productId].tsx
+++ b/shopper-app/src/pages/product/[productId].tsx
@@ -22,6 +22,7 @@ import TopBar from '@/components/TopBar';
 import { PageContext } from '@/context/Page';
 import RandomDeliveryDate from '@/components/DeliveryDate';
 import { LoginContext } from '@/context/Login';
+import { BrowserHistoryContext } from '@/context/BrowserHistory';
 
 interface Product {
   name: string;
@@ -104,6 +105,14 @@ export default function Product({ product }: ProductProp) {
   const router = useRouter();
   const { productId } = router.query;
   const { accessToken } = useContext(LoginContext);
+  const { productHistory, addProductToHistory} = useContext(BrowserHistoryContext);
+
+  React.useEffect(() => {
+    if (productId) {
+      addProductToHistory(productId as string);
+      console.log(productHistory);
+    }
+  }, [productId]);
 
   const handleSetValue = (value: string) => {
     setQuantity(parseInt(value));

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -206,11 +206,11 @@ export function Home() {
         
         if (productHistory.length  >= 1 && loginContext.id == '') {
           const historyImages = await Promise.all(
-            productHistory.slice(-4).map(async (productId) => {
-              const product = await fetchProduct(productId);
+            productHistory.slice(-4).map(async (browserhistory) => {
+              const product = await fetchProduct(browserhistory.productId);
               return {
                 image: product.image[0],
-                id: productId,
+                id: browserhistory.productId,
                 description: product.name,
                 title: product.name,
               };

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -143,7 +143,6 @@ const fetchProduct = async (productId: string): Promise<Product> => {
 
 const fetchBrowserHistory = async (memberId: string): Promise<[BrowserHistoryEntry]> => {
   try {
-    console.log(memberId);
     const query = {
       query: `
         query getBrowserHistory {
@@ -163,7 +162,6 @@ const fetchBrowserHistory = async (memberId: string): Promise<[BrowserHistoryEnt
       },
     });
     const json = await res.json();
-    console.log(json);
     if (json.errors) {
       console.error(json.errors[0].message);
       throw new Error(json.errors[0].message);
@@ -220,7 +218,6 @@ export function Home() {
           );
           setBrowserHistoryImages(historyImages);
         } else if (loginContext.id != '') {
-          console.log(loginContext.id);
           const historyEntries = await fetchBrowserHistory(loginContext.id);
           const historyImages = await Promise.all(
             historyEntries.map(async (entry) => {


### PR DESCRIPTION

Created browser history for logged out users and logged in users. Logged out users have browser history stored in the BrowserHistory Context, and logged in users have browser history stored in the backend. Logging in after being logged out will merge all previous browser history stored in local storage into the user's account.

**NOTE: merging will add productIds with the timestamp the user logs in with, although there is a separate timestamp stored in local context. this is bc i forgot to implement the POST endpoint to take in a timestamp query.... will fix later

### Backend

- Created new browser history table inside of member folder for each member's browsing history
- Added 3 new endpoints for /account:
    - POST /{memberId}/browser-history/{productId} adds a productId and timestamp to history table with member's id
    - GET /{memberId}/browser-history gets all products viewed with member's id
    - DELETE /{memberId}/browser-history deletes all products before a timestamp query under member's id

** All these endpoints are in graphql member folder as:
- addBrowserHistory
- getBrowserHistory
- deleteBrowserHistory    

### Frontend

- Created browsing history category that updates based on browsing history
<img width="1413" alt="Screenshot 2024-07-22 at 4 46 07 PM" src="https://github.com/user-attachments/assets/3879b87c-c473-4cef-8187-a58b3226b7df">