### PR TITLE
Fixing Home Page Categories

### DIFF
--- a/ProductService/src/category/controller.ts
+++ b/ProductService/src/category/controller.ts
@@ -16,6 +16,13 @@ export class CategoryController extends Controller {
     return await new CategoryService().getCategoriesOfProducts(productId);
   }
 
+  @Get('/min-products/{count}')
+  public async getCategoriesWithMinProducts(
+    @Path() count: number
+  ): Promise<Category[]> {
+    return await new CategoryService().getCategoriesWithMinProduct(count);
+  }
+
   @Get('/name/{categoryId}')
   @Response('404', 'Category Not Found')
   public async getCategoryById(

--- a/ProductService/src/category/service.ts
+++ b/ProductService/src/category/service.ts
@@ -10,6 +10,20 @@ export class CategoryService {
     return rows;
   }
 
+  public async getCategoriesWithMinProduct(count: number): Promise<Category[]> {
+    const select = ` SELECT c.id, c.name
+      FROM category c
+      JOIN product_category pc ON c.id = pc.category_id
+      GROUP BY c.id
+      HAVING COUNT(pc.product_id) >= $1;`;
+    const query = {
+      text: select,
+      values: [count]
+    };
+    const {rows} = await pool.query(query);
+    return rows;
+  }
+
   public async getCategoriesOfProducts(productId: string): Promise<Category[]> {
     const select = {
       text: 'SELECT category_id as id, name FROM category c JOIN product_category pc ON c.id = pc.category_id WHERE pc.product_id = $1',

--- a/shopper-app/src/components/CategoryCardMobile.tsx
+++ b/shopper-app/src/components/CategoryCardMobile.tsx
@@ -26,16 +26,17 @@ export default function CategoryCardMobile({ image, title }: CategoryCardMobileP
       type='rounded'
       elevation={0}
       sx={{
-        width: 'auto',
+        width: '100%',
         height: '180px',
-        margin: 1,
+        margin: 0.75,
         alignItems: 'top',
         maxHeight: '100%',
         maxWidth: screen.width < 500 ? screen.width / 3 - 12 : 140,
         justifyContent: 'center',
         display: 'flex',
         padding: 0,
-        overflow: 'hidden'
+        overflow: 'clip',
+        boxSizing: 'border-box',
       }}
     >
       <Stack width={screen.width < 500 ? screen.width / 3 - 16 : 128} height='176px' direction='column' display='flex' alignItems='center' margin='0.4rem' >

--- a/shopper-app/src/components/CategoryCardMobile.tsx
+++ b/shopper-app/src/components/CategoryCardMobile.tsx
@@ -30,7 +30,7 @@ export default function CategoryCardMobile({ image, title }: CategoryCardMobileP
         height: '180px',
         margin: 0.75,
         alignItems: 'top',
-        maxHeight: '100%',
+        maxHeight: '50vw',
         maxWidth: screen.width < 500 ? screen.width / 3 - 12 : 140,
         justifyContent: 'center',
         display: 'flex',

--- a/shopper-app/src/graphql/category/resolver.ts
+++ b/shopper-app/src/graphql/category/resolver.ts
@@ -15,4 +15,11 @@ export class CategoryResolver {
   ): Promise<[Category]> {
     return await new CategoryService().getCategoriesOfProduct(productId);
   }
+
+  @Query(() => [Category])
+  async getCategoriesWithMinProducts(
+    @Arg('count') count: number
+  ): Promise<[Category]> {
+    return await new CategoryService().getCategoriesWithMinProducts(count);
+  }
 }

--- a/shopper-app/src/graphql/category/service.ts
+++ b/shopper-app/src/graphql/category/service.ts
@@ -40,4 +40,23 @@ export class CategoryService {
       throw new Error('error in CategoryService: getCategoriesOfProduct');
     }
   }
+
+  public async getCategoriesWithMinProducts(count: number): Promise<[Category]> {
+    try {
+      const res = await fetch(
+        `http://localhost:${process.env.PRODUCT_SERVICE_PORT}/api/v0/category/min-products/${count}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      const json = await res.json();
+      return json;
+    } catch (e) {
+      console.error(e);
+      throw new Error('error in CategoryService: getCategoriesWithMinProducts');
+    }
+  }
 }

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -411,9 +411,9 @@ export function Home() {
           sx={{
             position: 'absolute',
             top: screen.width < 500 ? screen.width / 1.5 : 320,
-            width: '100%',
-            zIndex: 5000,
-            overflow: 'hidden'
+            width: '100vw',
+            zIndex: 3,
+            overflow: 'clip'
           }}
           justifyItems='left'
         >
@@ -423,10 +423,11 @@ export function Home() {
           sx={{
             background: 'linear-gradient(to bottom, transparent, #E4E6E6)',
             position: 'absolute',
-            zIndex: 10
+            zIndex: 2,
           }}
           top={screen.width < 500 ? screen.width/1.5 : 310}
           width="100%"
+          maxWidth="auto"
           height={screen.width < 500 ? screen.width/3 + 1 : 170}
           />
         <Box bgcolor='#E4E6E6' width="100%" height={screen.width < 500 ? screen.width/5 : 60}/>

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -411,9 +411,9 @@ export function Home() {
           sx={{
             position: 'absolute',
             top: screen.width < 500 ? screen.width / 1.5 : 320,
-            width: '100vw',
+            width: '100%',
             zIndex: 3,
-            overflow: 'clip'
+            overflow: 'clip',
           }}
           justifyItems='left'
         >

--- a/shopper-app/src/views/Home.tsx
+++ b/shopper-app/src/views/Home.tsx
@@ -187,12 +187,13 @@ const addBrowserHistory = async (memberId: string, productId: string): Promise<b
 const fetchCategories = async (): Promise<string[]> => {
   try {
     const query = {
-      query: `query getAllCategories {
-      getAllCategories {
-        name
-      }
-    }`,
+      query: `query getCategoriesWithMinProducts {
+        getCategoriesWithMinProducts(count: 4) {
+          name
+        }
+      }`,
     };
+
     const res = await fetch('/api/graphql', {
       method: 'POST',
       body: JSON.stringify(query),
@@ -200,12 +201,15 @@ const fetchCategories = async (): Promise<string[]> => {
         'Content-Type': 'application/json',
       },
     });
+
     const json = await res.json();
+    
     if (json.errors) {
-      console.error('Error fetching categoriess: ', json.errors);
-      throw new Error('Error fetching categoriess: ', json.errors);
+      console.error('Error fetching categories with minimum products: ', json.errors);
+      throw new Error('Error fetching categories with minimum products: ', json.errors);
     }
-    return json.data.getAllCategories.map((cat: { name: string }) => {return cat.name});
+
+    return json.data.getCategoriesWithMinProducts.map((cat: { name: string }) => cat.name);
   } catch (error) {
     console.error('Error fetching categories: ', error);
     throw error;


### PR DESCRIPTION
<img width="1426" alt="Screenshot 2024-09-25 at 12 00 03 AM" src="https://github.com/user-attachments/assets/9fceea74-ada6-4e72-891c-50830f0e3bbc">

Added new category service getCategoriesWithMinProducts to fetch for Home page products, so that home categories always displays full category boxes... (I gave up on adding new products T-T)

Backend:

- /categories/min-products/{count}: fetches categories with min of count # of products inside of them